### PR TITLE
Fixes prototype image and link paths.

### DIFF
--- a/_layouts/_haml/proto.haml
+++ b/_layouts/_haml/proto.haml
@@ -6,13 +6,13 @@ layout: base
 
 .prototype
   .proto-ani
-    %img{ src: "/images/{{ page.ani }}", alt: "{{ page.name }}" }
+    %img{ src: "/{{ site.baseurl }}/images/{{ page.ani }}", alt: "{{ page.name }}" }
 
   .proto-desc
     {{ content }}
 
     %p
-      %a{ href: "/{{ page.prototype-dir }}", target: "_blank" }
+      %a{ href: "/{{ site.baseurl }}/{{ page.prototype-dir }}", target: "_blank" }
         View the FramerJS prototype
 
     %p

--- a/_layouts/proto.html
+++ b/_layouts/proto.html
@@ -4,12 +4,12 @@ layout: base
 <h2>{{ page.name }}</h2>
 <div class='prototype'>
   <div class='proto-ani'>
-    <img alt='{{ page.name }}' src='/images/{{ page.ani }}'>
+    <img alt='{{ page.name }}' src='/{{ site.baseurl }}/images/{{ page.ani }}'>
   </div>
   <div class='proto-desc'>
     {{ content }}
     <p>
-      <a href='/{{ page.prototype-dir }}' target='_blank'>
+      <a href='/{{ site.baseurl }}/{{ page.prototype-dir }}' target='_blank'>
         View the FramerJS prototype
       </a>
     </p>


### PR DESCRIPTION
The paths for images and links need to be relative to the project, not the overall site. This should fix that by adding the {{ site.baseurl }} tags.